### PR TITLE
Make this library as an ESP IDF compatible component

### DIFF
--- a/AutoPID.cpp
+++ b/AutoPID.cpp
@@ -1,4 +1,15 @@
+#ifndef ESP_PLATFORM
 #include "AutoPID.h"
+#else
+#include <math.h>
+#include "esp_timer.h"
+#endif
+
+#ifdef ESP_PLATFORM
+unsigned long millis() {
+  return (unsigned long)esp_timer_get_time()/1000;
+}
+#endif
 
 AutoPID::AutoPID(double *input, double *setpoint, double *output, double outputMin, double outputMax,
                  double Kp, double Ki, double Kd) {
@@ -100,5 +111,3 @@ void AutoPIDRelay::run() {
 double AutoPIDRelay::getPulseValue(){
   return (isStopped()?0:_pulseValue);
 }
-
-

--- a/AutoPID.cpp
+++ b/AutoPID.cpp
@@ -8,6 +8,18 @@
 unsigned long millis() {
   return (unsigned long)esp_timer_get_time()/1000;
 }
+
+template<class T>
+const T& constrain(const T& x, const T& a, const T& b) {
+    if(x < a) {
+        return a;
+    }
+    else if(b < x) {
+        return b;
+    }
+    else
+        return x;
+}
 #endif
 
 AutoPID::AutoPID(double *input, double *setpoint, double *output, double outputMin, double outputMax,

--- a/AutoPID.cpp
+++ b/AutoPID.cpp
@@ -1,6 +1,5 @@
-#ifndef ESP_PLATFORM
 #include "AutoPID.h"
-#else
+#ifdef ESP_PLATFORM
 #include <math.h>
 #include "esp_timer.h"
 #endif

--- a/AutoPID.h
+++ b/AutoPID.h
@@ -1,6 +1,8 @@
 #ifndef AUTOPID_H
 #define AUTOPID_H
+#ifndef ESP_PLATFORM
 #include <Arduino.h>
+#endif
 
 class AutoPID {
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "AutoPID.cpp"
+                    INCLUDE_DIRS "."
+                    REQUIRES esp_common)


### PR DESCRIPTION
This PR adds preprocessor statements and replacement functions to make this library available as an ESP IDF compatible component which can easily be included in ESP IDF based projects.
Compatibility to the Arduino framework should be retained. This solved #14.