### PR TITLE
fix uninitialized value, fix unsigned calculation

### DIFF
--- a/AutoPID.cpp
+++ b/AutoPID.cpp
@@ -92,7 +92,9 @@ void AutoPID::setIntegral(double integral){
 
 void AutoPIDRelay::run() {
   AutoPID::run();
-  while ((millis() - _lastPulseTime) > _pulseWidth) _lastPulseTime += _pulseWidth;
+  const unsigned long currentTime = millis();
+  while (currentTime > (_pulseWidth + _lastPulseTime))
+    _lastPulseTime += _pulseWidth;
   *_relayState = ((millis() - _lastPulseTime) < (_pulseValue * _pulseWidth));
 }
 

--- a/AutoPID.h
+++ b/AutoPID.h
@@ -46,7 +46,7 @@ class AutoPIDRelay : public AutoPID {
   public:
 
     AutoPIDRelay(double *input, double *setpoint, bool *relayState, double pulseWidth, double Kp, double Ki, double Kd)
-      : AutoPID(input, setpoint, &_pulseValue, 0, 1.0, Kp, Ki, Kd) {
+      : AutoPID(input, setpoint, &_pulseValue, 0, 1.0, Kp, Ki, Kd), _lastPulseTime{millis()} {
       _relayState = relayState;
       _pulseWidth = pulseWidth;
     };


### PR DESCRIPTION
Thanks for the lib! I noticed that the Relay version has some bugs:
- _lastPulseTime was uninitialized, I set it to millis() to catch up quicker
- the _lastPulseTime computation in the while loop can go wrong on two unsigned values, especially with one uninitialized ;)

I also moved the millis() check out of the loop as I'd rather have a more robust PID that can always catch up to the millis() value in the while loop than the small speed improvement, if any. I am running an espresso machine with this and would hate to see it blow up ;)